### PR TITLE
Update go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/AppConfiguration-GoProvider/azureappconfiguration
 
-go 1.23.2
+go 1.23.0
 
 require github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig v1.2.0-beta.1
 


### PR DESCRIPTION
Based on [Release policy of Go](https://go.dev/doc/devel/release#policy), update the go version to 1.23.0